### PR TITLE
Sleep a few seconds after receiving messages

### DIFF
--- a/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
@@ -204,8 +204,8 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
         } else if (!messages.isEmpty() && this.queue.isKeepQueueMessages() == true) {
             try {
                 Thread.sleep(2000);
-            } catch(InterruptedException ex) {
-               Log.warning("Exception occurred %s while sleeping after message retrieval on %s", ex.toString(), this.channel);
+            } catch (InterruptedException ex) {
+               Log.warning("Exception %s occurred while sleeping after message retrieval on %s", ex.toString(), this.channel);
             }
         }
     }

--- a/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
@@ -201,6 +201,12 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
 
         if (this.notifyListeners(messages) && this.queue.isKeepQueueMessages() == false) {
             this.channel.deleteMessages(messages);
+        } else if (!messages.isEmpty() && this.queue.isKeepQueueMessages() == true) {
+            try {
+                Thread.sleep(2000);
+            } catch(InterruptedException ex) {
+               Log.warning("Exception occurred %s while sleeping after message retrieval on %s", ex.toString(), this.channel);
+            }
         }
     }
 


### PR DESCRIPTION
To prevent rapidly pulling down a large amount of messages from the SQS queue to only have them queue in Jenkins, we need to pause a few seconds after receiving message.  This will give time for the logic, to skip polling when there is a job queue, to catch up.